### PR TITLE
JSON Parse additional JSON Content-Type's

### DIFF
--- a/src/api/parser.test.ts
+++ b/src/api/parser.test.ts
@@ -10,6 +10,13 @@ describe('Body parsing', () => {
     expect(body).toEqual(json);
   });
 
+  it('Parses json body when charset is also defined in the context-type', () => {
+    const json = { hello: 'world' };
+    const headers = { 'content-type': 'application/json;charset=UTF-8' };
+    const body = new Body(JSON.stringify(json), headers).getParsedBody();
+    expect(body).toEqual(json);
+  });
+
   it('Parses form url encoded body', () => {
     const form = { hello: 'world' };
     const headers = { 'content-type': 'application/x-www-form-urlencoded' };

--- a/src/api/parser.ts
+++ b/src/api/parser.ts
@@ -54,6 +54,6 @@ export class Body {
   }
 
   private isJSON(contentType: string): boolean {
-    return contentType && contentType.toUpperCase() === 'APPLICATION/JSON';
+    return contentType && contentType.toUpperCase().includes('APPLICATION/JSON');
   }
 }


### PR DESCRIPTION
Increases the scope in which the wrapper will parse the request body as JSON to include `content-type`'s like (but not limited to) `application/json;charset=UTF-8`